### PR TITLE
Allow specifying the config file on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ A simple simulator which provides endpoints that mimic the functionality of [Azu
 
 ## Configuration
 
-Topics and their subscribers are configured in the `appsettings.json` file.
+Topics and their subscribers are configured in the `appsettings.json` file. Alternatively, you can specify the configuration file to use by setting the `ConfigFile` command line argument, e.g.
+
+```
+AzureEventGridSimulator.exe --ConfigFile=/page/to/config.json
+```
+
 You can add multiple topics. Each topic must have a unique port. Each topic can have multiple subscribers.
 An example of one topic with one subscriber is shown below.
 

--- a/src/UnitTests/ConfigurationLoadingTests.cs
+++ b/src/UnitTests/ConfigurationLoadingTests.cs
@@ -11,12 +11,50 @@ namespace UnitTests
         [Fact]
         public void TestConfigurationLoad()
         {
-            var json = "{\"topics\":[{\"name\":\"MyAwesomeTopic\",\"port\":60101,\"key\":\"TheLocal+DevelopmentKey=\",\"subscribers\":[{\"name\":\"LocalAzureFunctionSubscription\",\"endpoint\":\"http://localhost:7071/runtime/webhooks/EventGrid?functionName=PersistEventToDb\",\"filter\":{\"includedEventTypes\":[\"some.special.event.type\"],\"subjectBeginsWith\":\"MySubject\",\"subjectEndsWith\":\"_success\",\"isSubjectCaseSensitive\":true,\"advancedFilters\":[{\"operatorType\":\"NumberGreaterThanOrEquals\",\"key\":\"Data.Key1\",\"value\":5},{\"operatorType\":\"StringContains\",\"key\":\"Subject\",\"values\":[\"container1\",\"container2\"]}]}}]},{\"name\":\"ATopicWithNoSubscribers\",\"port\":60102,\"key\":\"TheLocal+DevelopmentKey=\",\"subscribers\":[]}]}";
+            var json = @"
+{
+    ""topics"": [{
+        ""name"": ""MyAwesomeTopic"",
+        ""port"": 60101,
+        ""key"": ""TheLocal+DevelopmentKey="",
+        ""subscribers"": [{
+            ""name"": ""LocalAzureFunctionSubscription"",
+            ""endpoint"":""http://localhost:7071/runtime/webhooks/EventGrid?functionName=PersistEventToDb"",
+            ""filter"": {
+                ""includedEventTypes"":[""some.special.event.type""],
+                ""subjectBeginsWith"":""MySubject"",
+                ""subjectEndsWith"":""_success"",
+                ""isSubjectCaseSensitive"":true,
+                ""advancedFilters"": [{
+                    ""operatorType"":""NumberGreaterThanOrEquals"",
+                    ""key"":""Data.Key1"",
+                    ""value"":5
+                },
+                {
+                    ""operatorType"":""StringContains"",
+                    ""key"":""Subject"",
+                    ""values"":[""container1"",""container2""
+                ]}
+            ]}
+        }]
+    },
+    {
+        ""name"":""ATopicWithNoSubscribers"",
+        ""port"":60102,
+        ""key"":""TheLocal+DevelopmentKey="",
+        ""subscribers"":[]
+    }]
+}";
 
             var settings = JsonConvert.DeserializeObject<SimulatorSettings>(json);
+
             settings.ShouldNotBeNull();
             settings.Topics.ShouldNotBeNull();
-            settings.Topics.ShouldAllBe(t => t.Subscribers.All(s => s.Filter != null) && t.Subscribers.All(s => s.Filter.AdvancedFilters != null));
+            settings.Topics.ShouldAllBe(t =>
+                t.Subscribers.All(s => s.Filter != null) &&
+                t.Subscribers.All(s => s.Filter.AdvancedFilters != null)
+            );
+
             Should.NotThrow(() => { settings.Validate(); });
         }
     }


### PR DESCRIPTION
This allows you to run the simulator multiple times with different configurations. Enabling you to store your config in source control, for example, without having to also store the exe in the same folder.