### PR TITLE
Relax of data filter setting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ The Azure Event Grid Simualator can mimick this behaviour using the `validationR
 
 #### Filtering Events
 
-Event filtering is configurable on each subscriber using the filter model defined here: https://docs.microsoft.com/en-us/azure/event-grid/event-filtering. This page provides a full guide to the configuration options available and all parts of this guide are currently supported. For ease of transition, explicit limitations have also been adhered to.
+Event filtering is configurable on each subscriber using the filter model defined here: https://docs.microsoft.com/en-us/azure/event-grid/event-filtering. This page provides a full guide to the configuration options available and all parts of this guide are currently supported. For ease of transition, explicit limitations have also been adhered to. 
+The restrictions mentioned have been further modified (https://azure.microsoft.com/en-us/updates/advanced-filtering-generally-available-in-event-grid/) and these new less restrictive filtering limits have been observed.
 
 Extending the example above to include a basic filter which will only deliver events to the subscription if they are of a specific type is illustrated below.
 
@@ -115,6 +116,7 @@ or advanced filtering:
   ]
 }
 ```
+
 
 ## Using the Simulator
 

--- a/src/AzureEventGridSimulator/Infrastructure/Extensions/SubscriptionSettingsFilterExtensions.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Extensions/SubscriptionSettingsFilterExtensions.cs
@@ -152,11 +152,19 @@ namespace AzureEventGridSimulator.Infrastructure.Extensions
                         var split = key.Split('.');
                         if (split[0] == (nameof(gridEvent.Data)) && gridEvent.Data != null && split.Length > 1)
                         {
-                            // look for the property on the grid event data object
-                            if (JObject.FromObject(gridEvent.Data).TryGetValue(split[1], out var dataValue))
+                            var tmpValue = gridEvent.Data;
+                            for (int i = 0; i < split.Length; i++)
                             {
-                                value = dataValue.ToObject<object>();
-                                retval = true;
+                                // look for the property on the grid event data object
+                                if (JObject.FromObject(tmpValue).TryGetValue(split[i], out var dataValue))
+                                {
+                                    tmpValue = dataValue.ToObject<object>();
+                                    if (i == split.Length - 1)
+                                    {
+                                        retval = true;
+                                        value = tmpValue;
+                                    }
+                                }
                             }
                         }
                         break;

--- a/src/AzureEventGridSimulator/Infrastructure/Settings/AdvancedFilterSetting.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Settings/AdvancedFilterSetting.cs
@@ -64,11 +64,6 @@ namespace AzureEventGridSimulator.Infrastructure.Settings
             {
                 throw new ArgumentOutOfRangeException(nameof(OperatorType), "Advanced filtering limits filters to five values for in and not in operators");
             }
-
-            if (Key.Count(c => c == '.') > 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(Key), "The key can only have one level of nesting (like data.key1)");
-            }
         }
 
         public override string ToString()

--- a/src/UnitTests/Filtering/AdvancedFilterEventAcceptanceTests.cs
+++ b/src/UnitTests/Filtering/AdvancedFilterEventAcceptanceTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Filtering
         private static readonly EventGridEvent GridEvent = new EventGridEvent
         {
             Id = "EventId",
-            Data = new { NumberValue = 1, IsTrue = true, Name = "StringValue", DoubleValue = 0.12345d, NumberMaxValue = ulong.MaxValue },
+            Data = new { NumberValue = 1, IsTrue = true, Name = "StringValue", DoubleValue = 0.12345d, NumberMaxValue = ulong.MaxValue, SubObject = new { Id = 1, Name = "Test" } },
             DataVersion = "5.0",
             EventTime = DateTime.UtcNow.ToString("O"),
             EventType = "this.is.a.test.event.type",
@@ -37,6 +37,49 @@ namespace UnitTests.Filtering
             var filterConfig = new FilterSetting { AdvancedFilters = new[] { filter } };
 
             filterConfig.AcceptsEvent(GridEvent).ShouldBeFalse($"{filter.Key} - {filter.OperatorType} - {filter.Value} - {filter.Values.Separate() }");
+        }
+
+        [Fact]
+        public void TestSimpleEventDataFilteringSuccess()
+        {
+            var filterConfig = new FilterSetting
+            {
+                AdvancedFilters = new[] {
+                    new AdvancedFilterSetting { Key = "Data", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberIn, Values = new object[]{ 1 } }
+                }
+            };
+            var gridEvent = new EventGridEvent { Data = 1 };
+
+            filterConfig.AcceptsEvent(gridEvent).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TestSimpleEventDataFilteringUsingValueSuccess()
+        {
+            var filterConfig = new FilterSetting
+            {
+                AdvancedFilters = new[] {
+                    new AdvancedFilterSetting { Key = "Data", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberGreaterThanOrEquals, Value = 1 },
+                    new AdvancedFilterSetting { Key = "Data", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberLessThanOrEquals, Value = 1 }
+                }
+            };
+            var gridEvent = new EventGridEvent { Data = 1 };
+
+            filterConfig.AcceptsEvent(gridEvent).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TestSimpleEventDataFilteringFailure()
+        {
+            var filterConfig = new FilterSetting
+            {
+                AdvancedFilters = new[] {
+                    new AdvancedFilterSetting { Key = "Data", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberIn, Value = 1 }
+                }
+            };
+            var gridEvent = new EventGridEvent { Data = 1 };
+
+            filterConfig.AcceptsEvent(gridEvent).ShouldBeFalse();
         }
     }
 }

--- a/src/UnitTests/Filtering/AdvancedFilterValidationTests.cs
+++ b/src/UnitTests/Filtering/AdvancedFilterValidationTests.cs
@@ -169,11 +169,12 @@ namespace UnitTests.Filtering
         [Fact]
         public void TestFilterValidationWithGrandchildKey()
         {
-            var filterConfig = new AdvancedFilterSetting { Key = "Data.Key1.SubKey", Value = "SomeValue" };
-            var exception = Should.Throw<ArgumentOutOfRangeException>(() => GetValidSimulatorSettings(filterConfig).Validate());
-
-            exception.ParamName.ShouldBe(nameof(filterConfig.Key));
-            exception.Message.ShouldBe("The key can only have one level of nesting (like data.key1)\r\nParameter name: Key");
+            // following the announcement here https://azure.microsoft.com/en-us/updates/advanced-filtering-generally-available-in-event-grid/ this should now work 
+            Should.NotThrow(() =>
+            {
+                var filterConfig = new AdvancedFilterSetting { Key = "Data.Key1.SubKey", Value = "SomeValue" };
+                GetValidSimulatorSettings(filterConfig).Validate();
+            });
         }
     }
 }

--- a/src/UnitTests/Filtering/NegativeFilterTestCaseContainer.cs
+++ b/src/UnitTests/Filtering/NegativeFilterTestCaseContainer.cs
@@ -134,6 +134,8 @@ namespace UnitTests.Filtering
                new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberLessThanOrEquals, Value = long.MaxValue },
                new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberLessThan, Value = ulong.MaxValue },
                new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberNotIn, Values = new object[] { ulong.MaxValue } },
+               new AdvancedFilterSetting { Key = "Data.SubObject.Name", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.StringIn, Values = new object[] { "Testing", "does", "not", "exist" } },
+               new AdvancedFilterSetting { Key = "Data.SubObject.Id", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberIn, Values = new object[] { 10, 11, 12 } }
             };
         }
 

--- a/src/UnitTests/Filtering/PositiveFilterTestCaseContainer.cs
+++ b/src/UnitTests/Filtering/PositiveFilterTestCaseContainer.cs
@@ -124,6 +124,8 @@ namespace UnitTests.Filtering
                 new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberIn, Values = new object[] { ulong.MaxValue } },
                 new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberLessThanOrEquals, Value = ulong.MaxValue },
                 new AdvancedFilterSetting { Key = "Data.NumberMaxValue", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberNotIn, Values = new object[] { long.MaxValue } },
+                new AdvancedFilterSetting { Key = "Data.SubObject.Name", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.StringIn, Values = new object[] { "Test" } },
+                new AdvancedFilterSetting { Key = "Data.SubObject.Id", OperatorType = AdvancedFilterSetting.OperatorTypeEnum.NumberIn, Values = new object[] { 1 } }
             };
         }
     }


### PR DESCRIPTION
Following the announcement here (https://azure.microsoft.com/en-us/updates/advanced-filtering-generally-available-in-event-grid) I have changed the advanced filtering implementation to support any depth filter definition on the data object.