### PR TITLE
Add aeg-sas-key header into dispatched events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,4 @@ ASALocalRun/
 /src/build-win-64
 /src/build-osx-64
 /src/build-linux-64
+/build-win-64

--- a/src/AzureEventGridSimulator/Domain/Services/SubscriptionValidationService.cs
+++ b/src/AzureEventGridSimulator/Domain/Services/SubscriptionValidationService.cs
@@ -88,6 +88,12 @@ namespace AzureEventGridSimulator.Domain.Services
                 {
                     var httpClient = _httpClientFactory.CreateClient();
                     httpClient.DefaultRequestHeaders.Add("aeg-event-type", "SubscriptionValidation");
+
+                    if (!string.IsNullOrEmpty(topic.Key))
+                    {
+                        httpClient.DefaultRequestHeaders.Add("aeg-sas-key", topic.Key);
+                    }
+
                     httpClient.Timeout = TimeSpan.FromSeconds(15);
 
                     subscription.ValidationStatus = SubscriptionValidationStatus.ValidationEventSent;


### PR DESCRIPTION
After switching from another no-longer maintained EventGrid emulator, I was getting errors due to the lack of the aeg-sas-key header when events are dispatched to subscribers.

This is a very basic PR to add those headers in for the auto-validation and the main event dispatcher.