### PR TITLE
Simulated health check

### DIFF
--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/BasicTests.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/BasicTests.cs
@@ -51,4 +51,21 @@ public class BasicTests
         response.EnsureSuccessStatusCode();
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task GivenAHealthRequest_ThenItShouldRespondWithOk()
+    {
+        // Arrange
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost:60101")
+        });
+
+        // Act
+        var response = await client.GetAsync("/api/health");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBe("OK");
+    }
 }

--- a/src/AzureEventGridSimulator/Controllers/HealthController.cs
+++ b/src/AzureEventGridSimulator/Controllers/HealthController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace AzureEventGridSimulator.Controllers;
+
+[Route("/api/health")]
+[ApiController]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok("OK");
+    }
+}

--- a/src/AzureEventGridSimulator/Infrastructure/Middleware/EventGridMiddleware.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Middleware/EventGridMiddleware.cs
@@ -38,6 +38,12 @@ public class EventGridMiddleware
             return;
         }
 
+        if (IsHealthRequest(context))
+        {
+            await ValidateHealthRequest(context);
+            return;
+        }
+
         // This is the end of the line.
         await context.WriteErrorResponse(HttpStatusCode.BadRequest, "Request not supported.", null);
     }
@@ -129,6 +135,11 @@ public class EventGridMiddleware
         await _next(context);
     }
 
+    private async Task ValidateHealthRequest(HttpContext context)
+    {
+        await _next(context);
+    }
+
     private static bool IsNotificationRequest(HttpContext context)
     {
         return context.Request.Headers.Keys.Any(k => string.Equals(k, "Content-Type", StringComparison.OrdinalIgnoreCase)) &&
@@ -143,5 +154,11 @@ public class EventGridMiddleware
                string.Equals(context.Request.Path, "/validate", StringComparison.OrdinalIgnoreCase) &&
                context.Request.Query.Keys.Any(k => string.Equals(k, "id", StringComparison.OrdinalIgnoreCase)) &&
                Guid.TryParse(context.Request.Query["id"], out _);
+    }
+
+    private static bool IsHealthRequest(HttpContext context)
+    {
+        return context.Request.Method == HttpMethods.Get &&
+            string.Equals(context.Request.Path, "/api/health", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Endpoint to emulate the health check exposed by Azure Event Grids as documented - https://docs.microsoft.com/en-us/azure/event-grid/custom-disaster-recovery-client-side#implement-client-side-failover

Due to invalid configurations resulting in an immediate termination of the simulator as well as there being no external dependencies which can fail; there can be no valid failure states and as such the only value that will ever be returned by the simulator is 200 OK.