### PR TITLE
Use WebApplicationFactory client as EventGridPublisherClient transport

### DIFF
--- a/src/AzureEventGridSimulator.Tests/ActualSimulatorTests/AzureMessagingEventGridTest.cs
+++ b/src/AzureEventGridSimulator.Tests/ActualSimulatorTests/AzureMessagingEventGridTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
@@ -10,9 +9,7 @@ using Xunit;
 namespace AzureEventGridSimulator.Tests.ActualSimulatorTests;
 
 /// <summary>
-/// Simple tests to check that we can send an event via Azure.Messaging.EventGrid library.
-/// NOTE: These tests require (and automatically start) an actual instance of AzureEventGridSimulator.exe as there is no way to inject an HttpClient (from a WebApplicationFactory)
-/// into Azure.Messaging.EventGrid.
+/// NOTE: These tests require (and automatically start) an actual instance of AzureEventGridSimulator.exe as WebApplicationFactory does not use a TCP connection (no port in use).
 /// </summary>
 [Collection(nameof(ActualSimulatorFixtureCollection))]
 [Trait("Category", "integration-actual")]
@@ -24,40 +21,6 @@ public class AzureMessagingEventGridTest
     public AzureMessagingEventGridTest(ActualSimulatorFixture actualSimulatorFixture)
     {
         _actualSimulatorFixture = actualSimulatorFixture;
-    }
-
-    [Fact]
-    public async Task GivenValidEvent_WhenUriContainsNonStandardPort_ThenItShouldBeAccepted()
-    {
-        var client = new EventGridPublisherClient(
-                                                  new Uri("https://localhost:60101/api/events"),
-                                                  new AzureKeyCredential("TheLocal+DevelopmentKey="),
-                                                  new EventGridPublisherClientOptions
-                                                      { Retry = { Mode = RetryMode.Fixed, MaxRetries = 0, NetworkTimeout = TimeSpan.FromSeconds(5) } });
-
-        var response = await client.SendEventAsync(new EventGridEvent("/the/subject", "The.Event.Type", "v1", new { Id = 1, Foo = "Bar" }));
-
-        response.Status.ShouldBe((int)HttpStatusCode.OK);
-    }
-
-    [Fact]
-    public async Task GivenValidEvents_WhenUriContainsNonStandardPort_TheyShouldBeAccepted()
-    {
-        var client = new EventGridPublisherClient(
-                                                  new Uri("https://localhost:60101/api/events"),
-                                                  new AzureKeyCredential("TheLocal+DevelopmentKey="),
-                                                  new EventGridPublisherClientOptions
-                                                      { Retry = { Mode = RetryMode.Fixed, MaxRetries = 0, NetworkTimeout = TimeSpan.FromSeconds(5) } });
-
-        var events = new[]
-        {
-            new EventGridEvent("/the/subject1", "The.Event.Type1", "v1", new { Id = 1, Foo = "Bar" }),
-            new EventGridEvent("/the/subject2", "The.Event.Type2", "v1", new { Id = 2, Foo = "Baz" })
-        };
-
-        var response = await client.SendEventsAsync(events);
-
-        response.Status.ShouldBe((int)HttpStatusCode.OK);
     }
 
     [Fact]
@@ -77,23 +40,5 @@ public class AzureMessagingEventGridTest
 
         exception.Message.ShouldContain("actively refused");
         exception.Status.ShouldBe(0);
-    }
-
-    [Fact]
-    public async Task GivenValidEvent_WhenKeyIsWrong_ThenItShouldNotBeAccepted()
-    {
-        var client = new EventGridPublisherClient(
-                                                  new Uri("https://localhost:60101/api/events"),
-                                                  new AzureKeyCredential("TheWrongLocal+DevelopmentKey="),
-                                                  new EventGridPublisherClientOptions
-                                                      { Retry = { Mode = RetryMode.Fixed, MaxRetries = 0, NetworkTimeout = TimeSpan.FromSeconds(5) } });
-
-        var exception = await Should.ThrowAsync<RequestFailedException>(async () =>
-        {
-            await client.SendEventAsync(new EventGridEvent("/the/subject", "The.Event.Type", "v1",
-                                                           new { Id = 1, Foo = "Bar" }));
-        });
-
-        exception.Status.ShouldBe((int)HttpStatusCode.Unauthorized);
     }
 }

--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/AzureMessagingEventGridTest.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/AzureMessagingEventGridTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Messaging.EventGrid;
+using AzureEventGridSimulator.Tests.ActualSimulatorTests;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.IntegrationTests;
+
+/// <summary>
+/// Simple tests to check that we can send an event via Azure.Messaging.EventGrid library.
+/// </summary>
+[Collection(nameof(ActualSimulatorFixtureCollection))]
+[Trait("Category", "integration-actual")]
+public class AzureMessagingEventGridTest : IClassFixture<IntegrationContextFixture>
+{
+    // ReSharper disable once NotAccessedField.Local
+    private readonly IntegrationContextFixture _factory;
+
+    public AzureMessagingEventGridTest(IntegrationContextFixture factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GivenValidEvent_WhenUriContainsNonStandardPort_ThenItShouldBeAccepted()
+    {
+        var client = _factory.CreateEventGridPublisherClient();
+
+        var response = await client.SendEventAsync(new EventGridEvent("/the/subject", "The.Event.Type", "v1", new { Id = 1, Foo = "Bar" }));
+
+        response.Status.ShouldBe((int)HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GivenValidEvents_WhenUriContainsNonStandardPort_TheyShouldBeAccepted()
+    {
+        var client = _factory.CreateEventGridPublisherClient();
+
+        var events = new[]
+        {
+            new EventGridEvent("/the/subject1", "The.Event.Type1", "v1", new { Id = 1, Foo = "Bar" }),
+            new EventGridEvent("/the/subject2", "The.Event.Type2", "v1", new { Id = 2, Foo = "Baz" })
+        };
+
+        var response = await client.SendEventsAsync(events);
+
+        response.Status.ShouldBe((int)HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GivenValidEvent_WhenKeyIsWrong_ThenItShouldNotBeAccepted()
+    {
+        var client = _factory.CreateEventGridPublisherClient(sasKey: "TheWrongLocal+DevelopmentKey=");
+
+        var exception = await Should.ThrowAsync<RequestFailedException>(async () =>
+        {
+            await client.SendEventAsync(new EventGridEvent("/the/subject", "The.Event.Type", "v1",
+                                                           new { Id = 1, Foo = "Bar" }));
+        });
+
+        exception.Status.ShouldBe((int)HttpStatusCode.Unauthorized);
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/IntegrationContextFixture.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/IntegrationContextFixture.cs
@@ -1,5 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core;
+using Azure.Messaging.EventGrid;
+using Azure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -20,6 +25,29 @@ public class IntegrationContextFixture : WebApplicationFactory<Program>, IAsyncL
     {
         Dispose();
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="EventGridPublisherClient" /> that uses the <see cref="WebApplicationFactory"/> HTTP transport.
+    /// </summary>
+    /// <param name="url">URL is used as an identifier in the target HttpContext but not for the network connection ie. WebApplicationFactory HTTP transport does not make use of ports.</param>
+    /// <param name="sasKey">Azure credential key</param>
+    /// <returns><see cref="EventGridPublisherClient" /></returns>
+    public EventGridPublisherClient CreateEventGridPublisherClient(string url = "https://localhost:60101/api/events", string sasKey = "TheLocal+DevelopmentKey=")
+    {
+        return new EventGridPublisherClient(
+                                          new Uri(url),
+                                          new AzureKeyCredential(sasKey),
+                                          new EventGridPublisherClientOptions
+                                          {
+                                              Retry =
+                                              {
+                                                  Mode = RetryMode.Fixed,
+                                                  MaxRetries = 0,
+                                                  NetworkTimeout = TimeSpan.FromSeconds(5)
+                                              },
+                                              Transport = new HttpClientTransport(CreateClient())
+                                          });
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)


### PR DESCRIPTION
A small change to the EventGridPublisherClient integration tests to make use a WebApplicationFactory client for transport instead of starting an instance of the .exe.