### PR TITLE
A configuration option to disable SSL certificates validity check

### DIFF
--- a/src/AzureEventGridSimulator/Program.cs
+++ b/src/AzureEventGridSimulator/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -175,7 +176,14 @@ public class Program
 
         builder.Services.AddSimulatorSettings(configuration);
         builder.Services.AddMediatR(o=> o.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
-        builder.Services.AddHttpClient();
+        var httpClientBuilder = builder.Services.AddHttpClient(string.Empty);
+        if (configuration.GetValue<bool>("DisableSslCertificatesValidation"))
+        {
+            httpClientBuilder.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            });
+        }
 
         builder.Services.AddScoped<SasKeyValidator>();
         builder.Services.AddSingleton<ValidationIpAddressProvider>();


### PR DESCRIPTION
In our project, we run both AzureEventGridSimulator and Azurite through Docker Compose. We find anything related to trusted HTTPS to be very complicated in such an environment. It is much more convenient to just disable SSL validation for development purposes.

In this pull request, I added a single boolean configuration property `DisableSslCertificatesValidation` that just disables this check if set to `true`. The default value is `false` to preserve current behavior.