### PR TITLE
Correct maximum event grid event size to latest value allowed by Azure Event Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ If you want to skip the validation then set the `Key` to _null_ in `appsettings.
 
 ### Size Validation
 
-Azure Event Grid imposes certain size limits to the overall message body and to the each individual event. The overall message body must be <= 1Mb and each individual event must be <= 64Kb. _These are the advertised size limits. My testing has shown that the actual limits are 1.5Mb and 65Kb._
+Azure Event Grid imposes certain size limits to the overall message body and to the each individual event. The overall message body and each individual event must be <= 1048576 bytes (1 Mb). _These are the advertised size limits. My testing has shown that the actual limits are 1536000 bytes (1.5 Mb) for the overall message body and 1049600 bytes (1 Mb) for each individual event._
 
 ### Message Validation
 

--- a/src/AzureEventGridSimulator/Infrastructure/Middleware/EventGridMiddleware.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Middleware/EventGridMiddleware.cs
@@ -86,7 +86,7 @@ public class EventGridMiddleware
         // Validate the overall body size and the size of each event.
         //
         const int maximumAllowedOverallMessageSizeInBytes = 1536000;
-        const int maximumAllowedEventGridEventSizeInBytes = 66560;
+        const int maximumAllowedEventGridEventSizeInBytes = 1049600;
 
         if (requestBody.Length > maximumAllowedOverallMessageSizeInBytes)
         {


### PR DESCRIPTION
The code that validates the individual message sizes, as well as the combined message size for each Event Grid event send was written in 2019.

Since then, Azure Event Grid has changed their maximum message size to 1 megabyte.

Sending a message that is over 64 KB unfortunately results in the following error:
"Event is larger than the allowed maximum."
which does not occur in production environments using the real Event Grid.

This is because the code still validates for 64 KB message sizes.

The validation should be updated to reflect the latest version of Azure Event Grid. The following program can be used to determine the actual limits of the Event Grid, using a real Event Grid, by testing various message sizes:
[test-event-grid-size-program.zip](https://github.com/user-attachments/files/22362318/test-event-grid-size-program.zip)

I used this to determine that the overall allowed message size is 1536000 bytes (1.5 MB) while each individual message can be 1049600 bytes (1 MB). The documented values are 1 MB for both overall allowed message size and individual message size: https://learn.microsoft.com/en-us/azure/event-grid/quotas-limits#events-limits-in-the-event-grid-namespace

Code and README adjusted accordingly.