### PR TITLE
feat(cloudevents): preserve extension attributes through ingestion and delivery

### DIFF
--- a/src/AzureEventGridSimulator.Tests/UnitTests/CloudEvents/CloudEventExtensionAttributesTests.cs
+++ b/src/AzureEventGridSimulator.Tests/UnitTests/CloudEvents/CloudEventExtensionAttributesTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using AzureEventGridSimulator.Domain;
+using AzureEventGridSimulator.Domain.Entities;
+using AzureEventGridSimulator.Domain.Services;
+using AzureEventGridSimulator.Tests.UnitTests.Common;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.UnitTests.CloudEvents;
+
+/// <summary>
+///     Tests that CloudEvents extension attributes (unknown top-level attributes) are preserved
+///     through the simulator pipeline: ingestion, storage and delivery to subscribers.
+///     This mirrors Azure Event Grid, which passes extension context attributes through unchanged.
+/// </summary>
+[Trait("Category", "unit")]
+public class CloudEventExtensionAttributesTests
+{
+    private readonly EventSchemaDetector _detector = new();
+    private readonly CloudEventSchemaParser _parser;
+    private readonly CloudEventSchemaFormatter _formatter = new();
+
+    public CloudEventExtensionAttributesTests()
+    {
+        _parser = new CloudEventSchemaParser(_detector);
+    }
+
+    [Fact]
+    public void GivenCloudEventWithExtensionAttribute_WhenSerialized_ThenAttributeIsReEmitted()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            SpecVersion = "1.0",
+            Type = "com.example.test",
+            Source = "/test/source",
+            Id = "test-id-123",
+            ExtensionAttributes = new Dictionary<string, JsonElement>
+            {
+                ["claimcheckurl"] = JsonSerializer.SerializeToElement(
+                    "http://localhost/some-payload.json"
+                ),
+            },
+        };
+
+        var simulatorEvent = SimulatorEvent.FromCloudEvent(cloudEvent);
+        var json = _formatter.SerializeSingle(simulatorEvent);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("claimcheckurl")
+            .GetString()
+            .ShouldBe("http://localhost/some-payload.json");
+    }
+
+    [Fact]
+    public void GivenStructuredModeRequestWithExtensionAttribute_WhenParsed_ThenAttributeIsCaptured()
+    {
+        var context = CreateStructuredModeContext();
+        const string requestBody = """
+            {
+                "specversion": "1.0",
+                "type": "com.example.test",
+                "source": "/test/source",
+                "id": "test-id-456",
+                "claimcheckurl": "http://localhost/payload.json"
+            }
+            """;
+
+        var events = _parser.Parse(context, requestBody);
+
+        var cloudEvent = events.ShouldHaveSingleItem().CloudEvent.ShouldNotBeNullAnd();
+        cloudEvent.ExtensionAttributes.ShouldNotBeNull();
+        cloudEvent
+            .ExtensionAttributes!["claimcheckurl"]
+            .GetString()
+            .ShouldBe("http://localhost/payload.json");
+    }
+
+    [Fact]
+    public void GivenBinaryModeRequestWithExtensionHeader_WhenParsed_ThenAttributeIsCaptured()
+    {
+        // In binary mode, extension attributes arrive as ce-<name> HTTP headers.
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                ContentType = "application/json",
+                Headers =
+                {
+                    [Constants.CeSpecVersionHeader] = "1.0",
+                    [Constants.CeTypeHeader] = "com.example.test",
+                    [Constants.CeSourceHeader] = "/test/source",
+                    [Constants.CeIdHeader] = "test-id-123",
+                    ["ce-claimcheckurl"] = "http://localhost/payload.json",
+                },
+            },
+        };
+
+        var events = _parser.Parse(context, "{\"Property\": \"Value\"}");
+
+        var cloudEvent = events.ShouldHaveSingleItem().CloudEvent.ShouldNotBeNullAnd();
+        cloudEvent.ExtensionAttributes.ShouldNotBeNull();
+        cloudEvent
+            .ExtensionAttributes!["claimcheckurl"]
+            .GetString()
+            .ShouldBe("http://localhost/payload.json");
+    }
+
+    [Fact]
+    public void GivenPublishedEventWithExtensionAttribute_WhenParsedAndDelivered_ThenAttributeSurvives()
+    {
+        // End-to-end: an extension attribute published to the simulator must reach subscribers,
+        // matching Azure Event Grid's pass-through behaviour. Delivery uses the batch array form.
+        var context = CreateStructuredModeContext();
+        const string requestBody = """
+            {
+                "specversion": "1.0",
+                "type": "com.example.test",
+                "source": "/test/source",
+                "id": "test-id-456",
+                "claimcheckurl": "http://localhost/payload.json"
+            }
+            """;
+
+        var events = _parser.Parse(context, requestBody);
+        var json = _formatter.Serialize(events.ShouldHaveSingleItem());
+
+        using var doc = JsonDocument.Parse(json);
+        var delivered = doc.RootElement;
+        delivered.GetArrayLength().ShouldBe(1);
+        delivered[0]
+            .GetProperty("claimcheckurl")
+            .GetString()
+            .ShouldBe("http://localhost/payload.json");
+    }
+
+    private static DefaultHttpContext CreateStructuredModeContext()
+    {
+        return new DefaultHttpContext
+        {
+            Request = { ContentType = "application/cloudevents+json" },
+        };
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/UnitTests/CloudEvents/CloudEventExtensionAttributesTests.cs
+++ b/src/AzureEventGridSimulator.Tests/UnitTests/CloudEvents/CloudEventExtensionAttributesTests.cs
@@ -106,6 +106,35 @@ public class CloudEventExtensionAttributesTests
     }
 
     [Fact]
+    public void GivenBinaryModeRequestWithEmptyExtensionHeader_WhenParsed_ThenAttributeIsPreserved()
+    {
+        // A present-but-empty ce-<name> header is still an extension attribute and must be
+        // preserved (matching GetHeaderValue, which keeps empty strings rather than dropping them).
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                ContentType = "application/json",
+                Headers =
+                {
+                    [Constants.CeSpecVersionHeader] = "1.0",
+                    [Constants.CeTypeHeader] = "com.example.test",
+                    [Constants.CeSourceHeader] = "/test/source",
+                    [Constants.CeIdHeader] = "test-id-123",
+                    ["ce-emptyext"] = "",
+                },
+            },
+        };
+
+        var events = _parser.Parse(context, "{\"Property\": \"Value\"}");
+
+        var cloudEvent = events.ShouldHaveSingleItem().CloudEvent.ShouldNotBeNullAnd();
+        cloudEvent.ExtensionAttributes.ShouldNotBeNull();
+        cloudEvent.ExtensionAttributes!.ShouldContainKey("emptyext");
+        cloudEvent.ExtensionAttributes["emptyext"].GetString().ShouldBe("");
+    }
+
+    [Fact]
     public void GivenPublishedEventWithExtensionAttribute_WhenParsedAndDelivered_ThenAttributeSurvives()
     {
         // End-to-end: an extension attribute published to the simulator must reach subscribers,

--- a/src/AzureEventGridSimulator/Domain/Entities/CloudEvent.cs
+++ b/src/AzureEventGridSimulator/Domain/Entities/CloudEvent.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using AzureEventGridSimulator.Infrastructure.JsonConverters;
 
@@ -87,6 +88,14 @@ public class CloudEvent
     [JsonPropertyName("data_base64")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DataBase64 { get; set; }
+
+    /// <summary>
+    ///     Gets or sets any CloudEvents extension context attributes (unknown top-level attributes).
+    ///     Azure Event Grid preserves extension attributes through ingestion and delivery, so we
+    ///     capture any unrecognised top-level attribute here and re-emit it to subscribers unchanged.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtensionAttributes { get; set; }
 
     [JsonIgnore]
     private DateTimeOffset? TimeParsed =>

--- a/src/AzureEventGridSimulator/Domain/Services/CloudEventSchemaParser.cs
+++ b/src/AzureEventGridSimulator/Domain/Services/CloudEventSchemaParser.cs
@@ -76,6 +76,7 @@ public partial class CloudEventSchemaParser(EventSchemaDetector schemaDetector) 
                 GetHeaderValue(headers, Constants.CeDataContentTypeHeader)
                 ?? context.Request.ContentType,
             DataSchema = GetHeaderValue(headers, Constants.CeDataSchemaHeader),
+            ExtensionAttributes = GetExtensionAttributesFromHeaders(headers),
         };
 
         // Parse the body as data
@@ -203,6 +204,60 @@ public partial class CloudEventSchemaParser(EventSchemaDetector schemaDetector) 
         }
 
         return events.Select(SimulatorEvent.FromCloudEvent).ToArray();
+    }
+
+    // CloudEvents binary-mode headers that map to known attributes; any other "ce-" header
+    // is an extension context attribute and must be preserved.
+    private static readonly HashSet<string> ReservedCeHeaders = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        Constants.CeSpecVersionHeader,
+        Constants.CeTypeHeader,
+        Constants.CeSourceHeader,
+        Constants.CeIdHeader,
+        Constants.CeTimeHeader,
+        Constants.CeSubjectHeader,
+        Constants.CeDataContentTypeHeader,
+        Constants.CeDataSchemaHeader,
+    };
+
+    private const string CeHeaderPrefix = "ce-";
+
+    /// <summary>
+    ///     Collects any "ce-" headers that are not known CloudEvents attributes into a dictionary of
+    ///     extension context attributes, keyed by the attribute name (the header name without "ce-").
+    /// </summary>
+    private static Dictionary<string, JsonElement>? GetExtensionAttributesFromHeaders(
+        IHeaderDictionary headers
+    )
+    {
+        Dictionary<string, JsonElement>? extensionAttributes = null;
+
+        foreach (var header in headers)
+        {
+            if (
+                !header.Key.StartsWith(CeHeaderPrefix, StringComparison.OrdinalIgnoreCase)
+                || ReservedCeHeaders.Contains(header.Key)
+            )
+            {
+                continue;
+            }
+
+            var value = header.Value.FirstOrDefault();
+            if (string.IsNullOrEmpty(value))
+            {
+                continue;
+            }
+
+            var name = header.Key[CeHeaderPrefix.Length..];
+            extensionAttributes ??= new Dictionary<string, JsonElement>(
+                StringComparer.OrdinalIgnoreCase
+            );
+            extensionAttributes[name] = JsonSerializer.SerializeToElement(DecodeHeaderValue(value));
+        }
+
+        return extensionAttributes;
     }
 
     /// <summary>

--- a/src/AzureEventGridSimulator/Domain/Services/CloudEventSchemaParser.cs
+++ b/src/AzureEventGridSimulator/Domain/Services/CloudEventSchemaParser.cs
@@ -244,8 +244,10 @@ public partial class CloudEventSchemaParser(EventSchemaDetector schemaDetector) 
                 continue;
             }
 
+            // Preserve present-but-empty extension headers (e.g. "ce-foo: ") rather than dropping
+            // them, matching GetHeaderValue. Only skip when the header carries no value at all.
             var value = header.Value.FirstOrDefault();
-            if (string.IsNullOrEmpty(value))
+            if (value is null)
             {
                 continue;
             }


### PR DESCRIPTION
## Summary

Closes #285.

The simulator only modelled the fixed CloudEvents v1.0 attributes, so any **extension context attribute** (e.g. `claimcheckurl`) on a published event was silently dropped during deserialization and never re-emitted to subscribers. Real Azure Event Grid passes extension attributes through unchanged, so this was a fidelity gap for anyone using extension attributes (e.g. claim-check metadata for oversized payloads).

### What changed

- **`CloudEvent` model** — added a `[JsonExtensionData] Dictionary<string, JsonElement>? ExtensionAttributes` property. Because the parser and formatter both round-trip the model object through `System.Text.Json`, this captures **and** re-emits unknown top-level attributes automatically for **structured** and **batch** JSON modes.
- **Binary mode** (`CloudEventSchemaParser`) — unknown `ce-*` HTTP headers are collected into the same dictionary (known/reserved `ce-*` headers excluded), reusing the existing percent-decoding so a value sent in binary mode matches the same value sent in structured mode.
- Kept it **lenient like Azure** — no enforcement of the CloudEvents lowercase-alphanumeric naming rule; pure pass-through.

### Tests

New `CloudEventExtensionAttributesTests` covering:
- structured-mode ingestion captures an unknown attribute
- binary-mode ingestion captures an unknown `ce-*` header
- re-emission on serialize
- full publish → parse → deliver round-trip (the exact `claimcheckurl` scenario from #285)

## Checklist

- [x] Tests pass (`dotnet test`) — 752/752
- [x] Build succeeds (`dotnet build`)
- [x] Commit messages use conventional format (`feat:`)
- [ ] Documentation updated (if applicable) — wiki Schema-Support page could note extension-attribute preservation (out of repo)

## Follow-ups (out of scope, surfaced by review)

These are **not** in this PR — flagging so they aren't lost:

1. **Advanced filters can't match extension attributes.** `SubscriptionSettingsFilterExtensions.TryGetValue` uses a fixed property switch, so extension attributes are now *deliverable* but not *filterable* — Azure can filter on them. This is the natural next slice to make the feature complete.
2. **Reserved `ce-*` header set is a hand-maintained mirror** of the model's known attributes and could drift if a new standard attribute is added to the model but not to the reserved set. Worth deriving from a single source of truth.
3. **CloudEvent → EventGrid-schema egress drops extension attributes** (no slot in the EventGrid schema). Likely inherent and matches Azure, but currently silent.