### PR TITLE
test: add delivery/handshake integration flows and filter key semantics

### DIFF
--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/CapturingHttpMessageHandler.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/CapturingHttpMessageHandler.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace AzureEventGridSimulator.Tests.IntegrationTests;
+
+/// <summary>
+///     A captured outbound HTTP request made by the simulator.
+/// </summary>
+public sealed class CapturedRequest
+{
+    public required string Method { get; init; }
+
+    public required string Url { get; init; }
+
+    public required string Body { get; init; }
+
+    public required IReadOnlyDictionary<string, string> Headers { get; init; }
+}
+
+/// <summary>
+///     Replaces the primary handler of the simulator's named HttpClient so
+///     integration tests can observe outbound deliveries without any network
+///     access. Acts as a fake subscriber: requests to the echo-handshaker.test
+///     host get the subscription validation code echoed back (the synchronous
+///     handshake); every other request gets a plain 200.
+/// </summary>
+public sealed class CapturingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly ConcurrentQueue<CapturedRequest> _requests = new();
+
+    public IReadOnlyList<CapturedRequest> Requests => _requests.ToArray();
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        var body =
+            request.Content == null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        var headers = request
+            .Headers.Concat(
+                request.Content?.Headers
+                    ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>()
+            )
+            .ToDictionary(
+                h => h.Key,
+                h => string.Join(",", h.Value),
+                StringComparer.OrdinalIgnoreCase
+            );
+
+        _requests.Enqueue(
+            new CapturedRequest
+            {
+                Method = request.Method.Method,
+                Url = request.RequestUri?.ToString() ?? "",
+                Body = body,
+                Headers = headers,
+            }
+        );
+
+        if (
+            string.Equals(
+                request.RequestUri?.Host,
+                "echo-handshaker.test",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            return CreateValidationEchoResponse(body);
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("", Encoding.UTF8),
+        };
+    }
+
+    private static HttpResponseMessage CreateValidationEchoResponse(string body)
+    {
+        // Behave like a well-implemented subscriber: read the validation code from
+        // the SubscriptionValidation event and echo it back synchronously.
+        using var doc = JsonDocument.Parse(body);
+        var validationCode = doc.RootElement[0]
+            .GetProperty("data")
+            .GetProperty("validationCode")
+            .GetGuid();
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                $$"""{"validationResponse":"{{validationCode}}"}""",
+                Encoding.UTF8,
+                "application/json"
+            ),
+        };
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/EventDeliveryFlowTests.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/EventDeliveryFlowTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+using AzureEventGridSimulator.Domain;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.IntegrationTests;
+
+/// <summary>
+///     End-to-end coverage of the simulator's core promise: a published event
+///     that matches a subscriber's filter is delivered to that subscriber, and
+///     a non-matching event is not. Outbound HTTP is captured by the fixture's
+///     CapturingHttpMessageHandler, so no network access is involved.
+/// </summary>
+[Trait("Category", "integration")]
+[Collection(nameof(IntegrationContextFixtureCollection))]
+public class EventDeliveryFlowTests(IntegrationContextFixture factory)
+{
+    private const string DeliveryCatcherHost = "delivery-catcher.test";
+
+    private HttpClient CreateTopicClient()
+    {
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions
+            {
+                BaseAddress = new Uri("https://localhost:60102"),
+            }
+        );
+
+        client.DefaultRequestHeaders.Add(Constants.AegSasKeyHeader, "TheLocal+DevelopmentKey=");
+        client.DefaultRequestHeaders.Add(
+            Constants.AegEventTypeHeader,
+            Constants.NotificationEventType
+        );
+
+        return client;
+    }
+
+    private async Task PublishEvent(string eventId, string eventType)
+    {
+        var client = CreateTopicClient();
+        var testEvent = new EventGridEvent("/test/subject", eventType, "1.0", new { Value = 1 })
+        {
+            Id = eventId,
+        };
+        var json = JsonSerializer.Serialize(new[] { testEvent });
+
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/api/events", content);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, responseBody);
+    }
+
+    private async Task<CapturedRequest> WaitForDelivery(string eventId)
+    {
+        // Delivery is asynchronous (the background service polls every second),
+        // so poll the captured requests with a generous timeout.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var delivered = factory.OutboundHttp.Requests.FirstOrDefault(r =>
+                r.Url.Contains(DeliveryCatcherHost, StringComparison.OrdinalIgnoreCase)
+                && r.Body.Contains(eventId, StringComparison.Ordinal)
+            );
+
+            if (delivered != null)
+            {
+                return delivered;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new ShouldAssertException(
+            $"Event {eventId} was not delivered to {DeliveryCatcherHost} within the timeout."
+        );
+    }
+
+    [Fact]
+    public async Task GivenEventMatchingSubscriberFilter_WhenPublished_ThenDeliveredToSubscriber()
+    {
+        var eventId = Guid.NewGuid().ToString();
+
+        await PublishEvent(eventId, "Deliver.Me");
+
+        var delivered = await WaitForDelivery(eventId);
+
+        delivered.Method.ShouldBe("POST");
+        delivered.Url.ShouldStartWith("https://delivery-catcher.test/events");
+        delivered.Headers[Constants.AegEventTypeHeader].ShouldBe(Constants.NotificationEventType);
+        delivered.Headers[Constants.AegSubscriptionNameHeader].ShouldBe("DELIVERYCATCHER");
+        delivered.Headers[Constants.AegDeliveryCountHeader].ShouldBe("1");
+
+        // The delivered payload is the event in EventGrid schema (array form)
+        using var doc = JsonDocument.Parse(delivered.Body);
+        doc.RootElement.GetArrayLength().ShouldBe(1);
+        doc.RootElement[0].GetProperty("id").GetString().ShouldBe(eventId);
+        doc.RootElement[0].GetProperty("eventType").GetString().ShouldBe("Deliver.Me");
+    }
+
+    [Fact]
+    public async Task GivenEventNotMatchingSubscriberFilter_WhenPublished_ThenNotDelivered()
+    {
+        var filteredOutId = Guid.NewGuid().ToString();
+        var matchingId = Guid.NewGuid().ToString();
+
+        // The non-matching event is accepted by the topic but filtered out at
+        // enqueue time; the matching event published afterwards acts as a
+        // barrier - once it has been delivered, the filtered event has had
+        // every opportunity to appear.
+        await PublishEvent(filteredOutId, "Ignore.Me");
+        await PublishEvent(matchingId, "Deliver.Me");
+
+        await WaitForDelivery(matchingId);
+
+        // Scope to the filtered subscriber: the unfiltered handshaker subscribers
+        // on the same topic legitimately receive the event.
+        factory
+            .OutboundHttp.Requests.Any(r =>
+                r.Url.Contains(DeliveryCatcherHost, StringComparison.OrdinalIgnoreCase)
+                && r.Body.Contains(filteredOutId, StringComparison.Ordinal)
+            )
+            .ShouldBeFalse("the filtered-out event must never reach the filtered subscriber");
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/IntegrationContextFixture.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/IntegrationContextFixture.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Xunit;
 
 namespace AzureEventGridSimulator.Tests.IntegrationTests;
@@ -7,6 +8,12 @@ namespace AzureEventGridSimulator.Tests.IntegrationTests;
 [UsedImplicitly]
 public class IntegrationContextFixture : WebApplicationFactory<Program>, IAsyncLifetime
 {
+    /// <summary>
+    ///     Captures every outbound HTTP request the simulator makes (deliveries
+    ///     and subscription validation events) and fakes the subscriber responses.
+    /// </summary>
+    public CapturingHttpMessageHandler OutboundHttp { get; } = new();
+
     public Task InitializeAsync()
     {
         return Task.CompletedTask;
@@ -35,6 +42,32 @@ public class IntegrationContextFixture : WebApplicationFactory<Program>, IAsyncL
         {
             logging.ClearProviders();
             logging.AddConsole();
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Route the simulator's outbound HTTP (deliveries, validation events)
+            // through the capturing handler instead of the network.
+            services
+                .AddHttpClient(nameof(AzureEventGridSimulator))
+                .ConfigurePrimaryHttpMessageHandler(() => OutboundHttp);
+
+            // The simulator binds SimulatorSettings from its own standalone
+            // configuration root (Program.BuildConfiguration), which never sees
+            // the json file added via ConfigureAppConfiguration above - it reads
+            // the default appsettings.json copied from the simulator project.
+            // Replace the singleton with settings genuinely bound from the test
+            // configuration file, mirroring AddSimulatorSettings.
+            var testConfiguration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.test.json", false, false)
+                .Build();
+
+            var testSettings = new Infrastructure.Settings.SimulatorSettings();
+            testConfiguration.Bind(testSettings);
+            testSettings.Validate();
+
+            services.AddSingleton(testSettings);
         });
     }
 }

--- a/src/AzureEventGridSimulator.Tests/IntegrationTests/SubscriptionHandshakeTests.cs
+++ b/src/AzureEventGridSimulator.Tests/IntegrationTests/SubscriptionHandshakeTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using AzureEventGridSimulator.Domain;
+using AzureEventGridSimulator.Domain.Commands;
+using AzureEventGridSimulator.Infrastructure.Mediator;
+using AzureEventGridSimulator.Infrastructure.Settings;
+using AzureEventGridSimulator.Infrastructure.Settings.Subscribers;
+using AzureEventGridSimulator.Tests.UnitTests.Common;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.IntegrationTests;
+
+/// <summary>
+///     End-to-end coverage of the subscription validation handshake: the
+///     synchronous echo flow (subscriber returns the validation code in the
+///     response) and the manual flow (subscriber calls the /validate URL).
+/// </summary>
+[Trait("Category", "integration")]
+[Collection(nameof(IntegrationContextFixtureCollection))]
+public class SubscriptionHandshakeTests(IntegrationContextFixture factory)
+{
+    private HttpSubscriberSettings GetSubscriber(string name)
+    {
+        var settings = factory.Services.GetRequiredService<SimulatorSettings>();
+        return settings
+            .Topics.Single(t => t.Name == "DeliveryFlowTopic")
+            .Subscribers.HttpSubscribers.Single(s => s.Name == name);
+    }
+
+    private HttpClient CreateTopicClient()
+    {
+        return factory.CreateClient(
+            new WebApplicationFactoryClientOptions
+            {
+                BaseAddress = new Uri("https://localhost:60102"),
+            }
+        );
+    }
+
+    private async Task TriggerValidationSweep()
+    {
+        var mediator = factory.Services.GetRequiredService<IMediator>();
+        await mediator.Send(new ValidateAllSubscriptionsCommand());
+    }
+
+    [Fact]
+    public async Task GivenSubscriberEchoesValidationCode_WhenValidationRuns_ThenSubscriberIsValidated()
+    {
+        // The capturing handler echoes the validation code back for the
+        // echo-handshaker.test endpoint (the synchronous handshake).
+        await TriggerValidationSweep();
+
+        GetSubscriber("EchoHandshaker")
+            .ValidationStatus.ShouldBe(SubscriptionValidationStatus.ValidationSuccessful);
+
+        var validationRequest = factory.OutboundHttp.Requests.FirstOrDefault(r =>
+            r.Url.StartsWith("https://echo-handshaker.test", StringComparison.OrdinalIgnoreCase)
+        );
+
+        var captured = validationRequest.ShouldNotBeNullAnd("no validation event was sent");
+        captured.Headers[Constants.AegEventTypeHeader].ShouldBe(Constants.ValidationEventType);
+        captured.Body.ShouldContain("Microsoft.EventGrid.SubscriptionValidationEvent");
+        captured.Body.ShouldContain("validationCode");
+        captured.Body.ShouldContain("validationUrl");
+    }
+
+    [Fact]
+    public async Task GivenSubscriberThatDoesNotEcho_WhenValidationUrlIsCalledWithCorrectCode_ThenValidated()
+    {
+        // The manual flow: the subscriber didn't echo synchronously, so it calls
+        // the /validate?id=<code> URL from the validation event instead.
+        var subscriber = GetSubscriber("ManualHandshaker");
+        var client = CreateTopicClient();
+
+        var response = await client.GetAsync($"/validate?id={subscriber.ValidationCode}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("successfully validated");
+        subscriber.ValidationStatus.ShouldBe(SubscriptionValidationStatus.ValidationSuccessful);
+    }
+
+    [Fact]
+    public async Task GivenWrongValidationCode_WhenValidationUrlIsCalled_ThenBadRequest()
+    {
+        var client = CreateTopicClient();
+
+        var response = await client.GetAsync($"/validate?id={Guid.NewGuid()}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).ShouldContain(
+            "The validation code was not correct"
+        );
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/CaseInsensitiveFilterKeyTests.cs
+++ b/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/CaseInsensitiveFilterKeyTests.cs
@@ -1,0 +1,108 @@
+using AzureEventGridSimulator.Infrastructure.Extensions;
+using AzureEventGridSimulator.Infrastructure.Settings;
+using AzureEventGridSimulator.Tests.UnitTests.Common;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.UnitTests.Filtering;
+
+/// <summary>
+///     Azure resolves filter keys case-insensitively, both for top-level event
+///     properties and for nested data paths.
+/// </summary>
+[Trait("Category", "unit")]
+public class CaseInsensitiveFilterKeyTests
+{
+    private static bool Evaluate(AdvancedFilterSetting filter)
+    {
+        var gridEvent = TestHelpers.CreateValidEventGridEvent(
+            data: new { Name = "StringValue", SubObject = new { Id = 5 } }
+        );
+        var filterConfig = new FilterSetting { AdvancedFilters = [filter] };
+
+        return filterConfig.AcceptsEvent(gridEvent);
+    }
+
+    [Theory]
+    [InlineData("EventType")]
+    [InlineData("eventtype")]
+    [InlineData("EVENTTYPE")]
+    public void GivenTopLevelKeyInAnyCase_WhenFilterEvaluated_ThenKeyResolves(string key)
+    {
+        Evaluate(
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.StringIn,
+                    Key = key,
+                    Values = ["Test.EventType"],
+                }
+            )
+            .ShouldBeTrue(key);
+    }
+
+    [Theory]
+    [InlineData("Id")]
+    [InlineData("id")]
+    [InlineData("ID")]
+    public void GivenIdKeyInAnyCase_WhenFilterEvaluated_ThenKeyResolves(string key)
+    {
+        Evaluate(
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.StringIn,
+                    Key = key,
+                    Values = ["test-id-123"],
+                }
+            )
+            .ShouldBeTrue(key);
+    }
+
+    [Theory]
+    [InlineData("Data.Name")]
+    [InlineData("data.name")]
+    [InlineData("DATA.NAME")]
+    public void GivenNestedDataKeyInAnyCase_WhenFilterEvaluated_ThenKeyResolves(string key)
+    {
+        Evaluate(
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.StringIn,
+                    Key = key,
+                    Values = ["StringValue"],
+                }
+            )
+            .ShouldBeTrue(key);
+    }
+
+    [Theory]
+    [InlineData("Data.SubObject.Id")]
+    [InlineData("data.subobject.id")]
+    [InlineData("DATA.SUBOBJECT.ID")]
+    public void GivenGrandchildKeyInAnyCase_WhenFilterEvaluated_ThenKeyResolves(string key)
+    {
+        Evaluate(
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.NumberIn,
+                    Key = key,
+                    Values = [5d],
+                }
+            )
+            .ShouldBeTrue(key);
+    }
+
+    [Fact]
+    public void GivenKeyCaseDiffersButValueDoesNotMatch_WhenFilterEvaluated_ThenEventRejected()
+    {
+        // Case-insensitive key resolution must not loosen the value comparison
+        Evaluate(
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.StringIn,
+                    Key = "DATA.NAME",
+                    Values = ["SomeOtherValue"],
+                }
+            )
+            .ShouldBeFalse();
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/MissingKeyFilterSemanticsTests.cs
+++ b/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/MissingKeyFilterSemanticsTests.cs
@@ -76,7 +76,7 @@ public class MissingKeyFilterSemanticsTests
     public void GivenKeyPresentWithNullValue_WhenIsNullOrUndefined_ThenEventAccepted()
     {
         var gridEvent = TestHelpers.CreateValidEventGridEvent(
-            data: new { NullableValue = (string?)null }
+            data: new { NullableValue = default(string) }
         );
         var filterConfig = new FilterSetting
         {
@@ -99,7 +99,7 @@ public class MissingKeyFilterSemanticsTests
     public void GivenKeyPresentWithNullValue_WhenIsNotNull_ThenEventRejected()
     {
         var gridEvent = TestHelpers.CreateValidEventGridEvent(
-            data: new { NullableValue = (string?)null }
+            data: new { NullableValue = default(string) }
         );
         var filterConfig = new FilterSetting
         {

--- a/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/MissingKeyFilterSemanticsTests.cs
+++ b/src/AzureEventGridSimulator.Tests/UnitTests/Filtering/MissingKeyFilterSemanticsTests.cs
@@ -1,0 +1,137 @@
+using AzureEventGridSimulator.Infrastructure.Extensions;
+using AzureEventGridSimulator.Infrastructure.Settings;
+using AzureEventGridSimulator.Tests.UnitTests.Common;
+using Shouldly;
+using Xunit;
+
+namespace AzureEventGridSimulator.Tests.UnitTests.Filtering;
+
+/// <summary>
+///     Pins Azure's documented (and counterintuitive) missing-key semantics:
+///     when the filter key is absent from the event, only NumberNotIn,
+///     NumberNotInRange and StringNotIn evaluate as matched - the other
+///     negation operators do NOT match, despite being negations.
+/// </summary>
+[Trait("Category", "unit")]
+public class MissingKeyFilterSemanticsTests
+{
+    private static bool EvaluateWithMissingKey(
+        AdvancedFilterSetting.AdvancedFilterOperatorType operatorType
+    )
+    {
+        var gridEvent = TestHelpers.CreateValidEventGridEvent(data: new { Name = "StringValue" });
+        var filterConfig = new FilterSetting
+        {
+            AdvancedFilters =
+            [
+                new AdvancedFilterSetting
+                {
+                    OperatorType = operatorType,
+                    Key = "Data.MissingKey",
+                    Value = "1",
+                    Values = [new object[] { 1d, 2d }],
+                },
+            ],
+        };
+
+        return filterConfig.AcceptsEvent(gridEvent);
+    }
+
+    [Theory]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberNotIn)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberNotInRange)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringNotIn)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.IsNullOrUndefined)]
+    public void GivenFilterKeyMissingFromEvent_WhenOperatorMatchesOnAbsence_ThenEventAccepted(
+        AdvancedFilterSetting.AdvancedFilterOperatorType operatorType
+    )
+    {
+        EvaluateWithMissingKey(operatorType).ShouldBeTrue(operatorType.ToString());
+    }
+
+    [Theory]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringNotContains)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringNotBeginsWith)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringNotEndsWith)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringIn)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringContains)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringBeginsWith)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.StringEndsWith)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberIn)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberInRange)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberGreaterThan)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberGreaterThanOrEquals)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberLessThan)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.NumberLessThanOrEquals)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.BoolEquals)]
+    [InlineData(AdvancedFilterSetting.AdvancedFilterOperatorType.IsNotNull)]
+    public void GivenFilterKeyMissingFromEvent_WhenOperatorRequiresPresence_ThenEventRejected(
+        AdvancedFilterSetting.AdvancedFilterOperatorType operatorType
+    )
+    {
+        EvaluateWithMissingKey(operatorType).ShouldBeFalse(operatorType.ToString());
+    }
+
+    [Fact]
+    public void GivenKeyPresentWithNullValue_WhenIsNullOrUndefined_ThenEventAccepted()
+    {
+        var gridEvent = TestHelpers.CreateValidEventGridEvent(
+            data: new { NullableValue = (string?)null }
+        );
+        var filterConfig = new FilterSetting
+        {
+            AdvancedFilters =
+            [
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting
+                        .AdvancedFilterOperatorType
+                        .IsNullOrUndefined,
+                    Key = "Data.NullableValue",
+                },
+            ],
+        };
+
+        filterConfig.AcceptsEvent(gridEvent).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenKeyPresentWithNullValue_WhenIsNotNull_ThenEventRejected()
+    {
+        var gridEvent = TestHelpers.CreateValidEventGridEvent(
+            data: new { NullableValue = (string?)null }
+        );
+        var filterConfig = new FilterSetting
+        {
+            AdvancedFilters =
+            [
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.IsNotNull,
+                    Key = "Data.NullableValue",
+                },
+            ],
+        };
+
+        filterConfig.AcceptsEvent(gridEvent).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenKeyPresentWithValue_WhenIsNotNull_ThenEventAccepted()
+    {
+        var gridEvent = TestHelpers.CreateValidEventGridEvent(data: new { Name = "StringValue" });
+        var filterConfig = new FilterSetting
+        {
+            AdvancedFilters =
+            [
+                new AdvancedFilterSetting
+                {
+                    OperatorType = AdvancedFilterSetting.AdvancedFilterOperatorType.IsNotNull,
+                    Key = "Data.Name",
+                },
+            ],
+        };
+
+        filterConfig.AcceptsEvent(gridEvent).ShouldBeTrue();
+    }
+}

--- a/src/AzureEventGridSimulator.Tests/appsettings.test.json
+++ b/src/AzureEventGridSimulator.Tests/appsettings.test.json
@@ -22,6 +22,31 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "DeliveryFlowTopic",
+            "port": 60102,
+            "key": "TheLocal+DevelopmentKey=",
+            "subscribers": {
+                "http": [
+                    {
+                        "name": "DeliveryCatcher",
+                        "endpoint": "https://delivery-catcher.test/events",
+                        "disableValidation": true,
+                        "filter": {
+                            "includedEventTypes": [ "Deliver.Me" ]
+                        }
+                    },
+                    {
+                        "name": "EchoHandshaker",
+                        "endpoint": "https://echo-handshaker.test/events"
+                    },
+                    {
+                        "name": "ManualHandshaker",
+                        "endpoint": "https://manual-handshaker.test/events"
+                    }
+                ]
+            }
         }
     ],
     "Serilog": {


### PR DESCRIPTION
## Summary

Adds **40 tests** (suite: 909 total, all passing) closing the last high-value gaps identified in the deep-dive test review — the end-to-end delivery and subscription handshake flows, plus the missing-key and case-insensitive filter key semantics. Follows on from #289.

## What's covered

| Area | Tests |
| --- | --- |
| `EventDeliveryFlowTests` — the simulator's core promise end to end: a published event matching a subscriber's filter is delivered (payload, `aeg-*` headers, delivery count), and a filtered-out event never reaches that subscriber | 2 |
| `SubscriptionHandshakeTests` — synchronous echo handshake (subscriber echoes `validationResponse`), the manual `/validate?id=` flow, and rejection of a wrong validation code | 3 |
| `MissingKeyFilterSemanticsTests` — pins Azure's counterintuitive missing-key rules: only `NumberNotIn`/`NumberNotInRange`/`StringNotIn` match when the filter key is absent; the other negation operators do **not**, plus `IsNullOrUndefined`/`IsNotNull` null-vs-missing distinctions | 22 |
| `CaseInsensitiveFilterKeyTests` — filter keys resolve case-insensitively at top level and through nested data paths, without loosening value comparison | 13 |

## How the flows are tested

A new `CapturingHttpMessageHandler` is installed as the primary handler of the simulator's named `HttpClient`, so all outbound HTTP (event deliveries and subscription validation events) is captured and faked in-process — no network access. It acts as a well-behaved subscriber: requests to the `echo-handshaker.test` endpoint get the validation code echoed back synchronously.

## 🐛 Latent test-infrastructure bug found and fixed

**`appsettings.test.json` was never actually used by the simulator under `WebApplicationFactory`.** `AddSimulatorSettings` binds `SimulatorSettings` from Program's standalone configuration root (`BuildConfiguration()`), which reads only the default `appsettings.json` copied into the test output from the simulator project — the config file added via `ConfigureAppConfiguration` feeds the host configuration, which the simulator's settings binding never sees.

The existing integration tests passed against the **default** config by coincidence: it happens to define a topic on port 60101 with the same key. This surfaced when a new test topic on port 60102 collided with the default config's `CloudEventsTopic` (`inputSchema: CloudEventV1_0`) and events started being rejected with a CloudEvents schema error.

The fixture now replaces the `SimulatorSettings` singleton with settings genuinely bound from `appsettings.test.json` (mirroring `AddSimulatorSettings`), so the test configuration finally means what it says.

## Deliberately not tested (poor cost/benefit)

`RetryDeliveryBackgroundService` workflow (its components are already covered), `ValidateAllSubscriptionsCommandHandler` cancellation/disposal (implementation detail), the 5-minute handshake expiry boundary (needs a production `TimeProvider` refactor first), and `Program.cs` startup failure propagation (slow real-process test for an unlikely regression).

## Verification

- `dotnet test` — 909 passed, 0 failed, 0 skipped
- Full suite run 5× consecutively — stable every run (async delivery tests poll with timeout; no sleeps)