### PR TITLE
chore(deps): bump MessagePack to 3.1.7 and tidy package references

### DIFF
--- a/src/AzureEventGridSimulator.AppHost/AzureEventGridSimulator.AppHost.csproj
+++ b/src/AzureEventGridSimulator.AppHost/AzureEventGridSimulator.AppHost.csproj
@@ -13,6 +13,8 @@
         <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
         <PackageReference Include="Aspire.Hosting.Azure.EventHubs" />
         <PackageReference Include="Aspire.Hosting.SqlServer" />
+        <!-- Security pin: forces patched MessagePack over the vulnerable version the Aspire
+             SDK pulls transitively (GHSA-hv8m-jj95-wg3x). Not used by our code directly. -->
         <PackageReference Include="MessagePack" />
     </ItemGroup>
 

--- a/src/AzureEventGridSimulator/AzureEventGridSimulator.csproj
+++ b/src/AzureEventGridSimulator/AzureEventGridSimulator.csproj
@@ -33,7 +33,6 @@
         <PackageReference Include="Asp.Versioning.Mvc" />
         <PackageReference Include="JetBrains.Annotations" />
         <PackageReference Include="Serilog.AspNetCore" />
-        <PackageReference Include="Serilog.Extensions.Logging" />
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,9 +7,14 @@
         <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
         <!-- Serilog -->
         <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-        <PackageVersion Include="MessagePack" Version="2.5.301" />
+        <!--
+            Not referenced by any of our code. This is a transitive dependency of the Aspire
+            AppHost SDK, which otherwise resolves the vulnerable MessagePack 2.5.192
+            (GHSA-hv8m-jj95-wg3x). The explicit reference in the AppHost project forces the
+            patched version; do not remove until Aspire ships a fixed transitive version.
+        -->
+        <PackageVersion Include="MessagePack" Version="3.1.7" />
         <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-        <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
## What & why

Supersedes Dependabot #295 (MessagePack `2.5.301` → `3.1.7`) and folds in two related package-hygiene changes.

### 1. MessagePack security pin → 3.1.7
MessagePack isn't referenced by any of our code — it's a **security pin** in the Aspire AppHost project that forces a patched version over the vulnerable one the Aspire SDK resolves transitively (`2.5.192`, GHSA-hv8m-jj95-wg3x). `3.1.7` additionally fixes **3 high + 9 moderate** severity advisories. A comment now documents *why* the pin exists so it isn't mistaken for an unused dependency and removed.

### 2. Remove redundant `Serilog.Extensions.Logging` reference
It's the Microsoft.Extensions.Logging↔Serilog provider bridge (`SerilogLoggerProvider`), pulled in **transitively** via `Serilog.AspNetCore` at the same `10.0.0` and wired in code via `UseSerilog()`. It is **not** a sink/enricher, so it can't be loaded via Serilog's `Using`/`WriteTo` config either — the explicit pin was redundant. Verified the assembly still resolves at 10.0.0 and ships, and a runtime boot still logs correctly.

## Verification
- ✅ `dotnet build` clean — **0 warnings** (warnings-as-errors is on)
- ✅ **909/909** tests pass on net10.0
- ✅ Runtime smoke test: app boots and Serilog Console + File sinks load/write
- ℹ️ Dependabot already ran green on 3.1.7 across windows/ubuntu/macos in #295