### PR TITLE
feat!: drop .NET 8/9 support, target .NET 10 only, and upgrade packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "snyk.advanced.autoSelectOrganization": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "snyk.advanced.autoSelectOrganization": true
+  "snyk.advanced.autoSelectOrganization": false
 }

--- a/src/AzureEventGridSimulator.AppHost/AzureEventGridSimulator.AppHost.csproj
+++ b/src/AzureEventGridSimulator.AppHost/AzureEventGridSimulator.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.4">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>

--- a/src/AzureEventGridSimulator.ServiceDefaults/AzureEventGridSimulator.ServiceDefaults.csproj
+++ b/src/AzureEventGridSimulator.ServiceDefaults/AzureEventGridSimulator.ServiceDefaults.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <!-- Multi-target to match main app (clears TargetFramework from Directory.Build.props) -->
-        <TargetFramework></TargetFramework>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <!-- TargetFramework (net10.0) is inherited from Directory.Build.props -->
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/src/AzureEventGridSimulator/AzureEventGridSimulator.csproj
+++ b/src/AzureEventGridSimulator/AzureEventGridSimulator.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <!-- Multi-target for .NET Tool compatibility (clears TargetFramework from Directory.Build.props) -->
-        <TargetFramework></TargetFramework>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <!-- TargetFramework (net10.0) is inherited from Directory.Build.props -->
         <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
 
         <!-- .NET Tool packaging -->

--- a/src/AzureEventGridSimulator/Domain/Services/EventSchemaDetector.cs
+++ b/src/AzureEventGridSimulator/Domain/Services/EventSchemaDetector.cs
@@ -47,8 +47,11 @@ public class EventSchemaDetector
         }
 
         // Check for CloudEvents JSON content type (use base types for detection)
-        return contentType.Contains(Constants.CloudEventsContentTypeBase)
-            || contentType.Contains(Constants.CloudEventsBatchContentTypeBase);
+        return contentType.Contains(Constants.CloudEventsContentTypeBase, StringComparison.Ordinal)
+            || contentType.Contains(
+                Constants.CloudEventsBatchContentTypeBase,
+                StringComparison.Ordinal
+            );
     }
 
     /// <summary>
@@ -91,6 +94,9 @@ public class EventSchemaDetector
     {
         var contentType = context.Request.ContentType;
         return !string.IsNullOrEmpty(contentType)
-            && contentType.Contains(Constants.CloudEventsBatchContentTypeBase);
+            && contentType.Contains(
+                Constants.CloudEventsBatchContentTypeBase,
+                StringComparison.Ordinal
+            );
     }
 }

--- a/src/AzureEventGridSimulator/Infrastructure/Dashboard/DashboardMiddleware.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Dashboard/DashboardMiddleware.cs
@@ -61,7 +61,10 @@ public class DashboardMiddleware
                 : path["/dashboard/".Length..];
 
         // Security: prevent directory traversal
-        if (resourcePath.Contains("..") || resourcePath.Contains("\\"))
+        if (
+            resourcePath.Contains("..", StringComparison.Ordinal)
+            || resourcePath.Contains("\\", StringComparison.Ordinal)
+        )
         {
             context.Response.StatusCode = 400;
             return;

--- a/src/AzureEventGridSimulator/Infrastructure/Extensions/KestrelServerOptionsExtensions.cs
+++ b/src/AzureEventGridSimulator/Infrastructure/Extensions/KestrelServerOptionsExtensions.cs
@@ -21,14 +21,10 @@ public static class KestrelServerOptionsExtensions
         if (certificateFileSpecified && certificatePasswordSpecified)
         {
             // The certificate file and password was specified.
-#if NET9_0_OR_GREATER
             certificate = X509CertificateLoader.LoadPkcs12FromFile(
                 certificateFile!,
                 certificatePassword
             );
-#else
-            certificate = new X509Certificate2(certificateFile!, certificatePassword);
-#endif
         }
         else if (certificateFileSpecified)
         {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     </PropertyGroup>
     <ItemGroup>
         <!-- Main Application -->
-        <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
+        <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
         <!-- Serilog -->
         <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
         <!--
@@ -15,7 +15,7 @@
         -->
         <PackageVersion Include="MessagePack" Version="3.1.7" />
         <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-        <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+        <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageVersion Include="Serilog.Sinks.Seq" Version="9.1.0" />
@@ -23,26 +23,26 @@
         <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
         <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
         <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-        <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
+        <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
         <!-- Aspire (Aspire.Hosting.AppHost comes implicitly from the Aspire.AppHost.Sdk) -->
-        <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.3.3" />
-        <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.3" />
-        <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="13.3.3" />
-        <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.3" />
-        <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-        <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.4" />
+        <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.4" />
+        <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="13.4.4" />
+        <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.4" />
+        <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+        <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
         <!-- Analyzers -->
-        <PackageVersion Include="Meziantou.Analyzer" Version="3.0.85" />
+        <PackageVersion Include="Meziantou.Analyzer" Version="3.0.104" />
         <!-- Testing -->
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
         <PackageVersion Include="coverlet.collector" Version="10.0.1" />


### PR DESCRIPTION
## ⚠️ Breaking change

The published global tool now **requires the .NET 10 runtime**. Users on the .NET 8 or 9 runtimes can no longer install or run `azure-eventgrid-simulator` and must upgrade to .NET 10. (Marked `feat!` / `BREAKING CHANGE:` so release-please bumps the **major** version.)

## What & why

### Target .NET 10 only
- Removed multi-targeting (`net8.0;net9.0;net10.0` → `net10.0`) from the main app and ServiceDefaults projects; both now inherit `net10.0` from `Directory.Build.props`.
- Simplified Kestrel certificate loading — dropped the `#if NET9_0_OR_GREATER` fork so `X509CertificateLoader` is used unconditionally.
- Dockerfile, CI workflows, and `global.json` were already net10-centric — no change needed.

### Upgrade packages accordingly
| Package | From → To |
|---|---|
| **Asp.Versioning.Mvc** | 8.1.1 → **10.0.0** (tracks the .NET major) |
| Aspire.Hosting.* + Aspire.AppHost.Sdk | 13.3.3 → 13.4.4 |
| Microsoft.Extensions.Http.Resilience / ServiceDiscovery | 10.6.0 → 10.7.0 |
| OpenTelemetry.Exporter.OTLP / Extensions.Hosting | 1.15.3 → 1.16.0 |
| Meziantou.Analyzer | 3.0.85 → 3.0.104 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.8 → 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.5.1 → 18.6.0 |
| Azure.Storage.Queues | 12.26.0 → 12.27.0 |
| Serilog.Settings.Configuration | 10.0.0 → 10.0.1 |

The `Meziantou.Analyzer` bump tightened **MA0074**; added explicit `StringComparison.Ordinal` to the affected `string.Contains` calls in `EventSchemaDetector` and `DashboardMiddleware` — behaviour-neutral (ordinal is already the default).

## Verification
- ✅ `dotnet build` clean — **0 warnings** (warnings-as-errors is on)
- ✅ **909/909** tests pass on net10.0
- ✅ CSharpier-formatted